### PR TITLE
Feat/engine builder node

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,19 @@ cd ./ComfyUI-Depth-Anything-Tensorrt
 pip install -r requirements.txt
 ```
 
-## 🛠️ Building Tensorrt Engine
+## 🛠️ Building TensorRT Engine
 
+There are two ways to build TensorRT engines:
+
+### Method 1: Using the EngineBuilder Node
+1. Insert node by `Right Click -> tensorrt -> Depth Anything Engine Builder`
+2. Select the model version (v1 or v2) and size (small, base, or large)
+3. Optionally customize the engine name, FP16 settings, and onnx path
+4. Run the workflow to build the engine
+
+The engine will be automatically downloaded and built in the specified location. Refresh the webpage or strike 'r' on your keyboard, and the new engine will appear in the Depth Anything Tensorrt node. 
+
+### Method 2: Manual Building
 1. Download one of the available onnx models:
    - [Depth Anything v1](https://huggingface.co/yuvraj108c/Depth-Anything-Onnx/tree/main)
    - [Depth Anything v2](https://huggingface.co/yuvraj108c/Depth-Anything-2-Onnx/tree/main)

--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ import torch
 from comfy.utils import ProgressBar
 import cv2
 from .utilities import Engine
+from .engine_builder_node import DepthAnythingEngineBuilder
 
 ENGINE_DIR = os.path.join(folder_paths.models_dir,"tensorrt", "depth-anything")
 
@@ -64,10 +65,12 @@ class DepthAnythingTensorrt:
 
 NODE_CLASS_MAPPINGS = { 
     "DepthAnythingTensorrt" : DepthAnythingTensorrt,
+    "DepthAnythingEngineBuilder" : DepthAnythingEngineBuilder,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
      "DepthAnythingTensorrt" : "Depth Anything Tensorrt",
+     "DepthAnythingEngineBuilder" : "Depth Anything Engine Builder",
 }
 
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/engine_builder_node.py
+++ b/engine_builder_node.py
@@ -1,0 +1,142 @@
+import os
+import folder_paths
+from .export_trt import export_trt
+import urllib.request
+import shutil
+
+ENGINE_DIR = os.path.join(folder_paths.models_dir,"tensorrt", "depth-anything")
+ONNX_DIR = os.path.join(folder_paths.models_dir,"onnx", "depth-anything")
+
+# Model URLs and configurations
+DEPTH_ANYTHING_MODELS = {
+    "v1_small": {
+        "url": "https://huggingface.co/yuvraj108c/Depth-Anything-Onnx/resolve/main/depth_anything_vits14.onnx",
+        "filename": "depth_anything_vits14.onnx",
+        "engine_name": "v1_depth_anything_vits14-fp16.engine"
+    },
+    "v1_base": {
+        "url": "https://huggingface.co/yuvraj108c/Depth-Anything-Onnx/resolve/main/depth_anything_vitb14.onnx",
+        "filename": "depth_anything_vitb14.onnx",
+        "engine_name": "v1_depth_anything_vitb14-fp16.engine"
+    },
+    "v1_large": {
+        "url": "https://huggingface.co/yuvraj108c/Depth-Anything-Onnx/resolve/main/depth_anything_vitl14.onnx",
+        "filename": "depth_anything_vitl14.onnx",
+        "engine_name": "v1_depth_anything_vitl14-fp16.engine"
+    },
+    "v2_small": {
+        "url": "https://huggingface.co/yuvraj108c/Depth-Anything-2-Onnx/resolve/main/depth_anything_v2_vits.onnx",
+        "filename": "depth_anything_v2_vits.onnx",
+        "engine_name": "v2_depth_anything_v2_vits-fp16.engine"
+    },
+    "v2_base": {
+        "url": "https://huggingface.co/yuvraj108c/Depth-Anything-2-Onnx/resolve/main/depth_anything_v2_vitb.onnx",
+        "filename": "depth_anything_v2_vitb.onnx",
+        "engine_name": "v2_depth_anything_v2_vitb-fp16.engine"
+    },
+    "v2_large": {
+        "url": "https://huggingface.co/yuvraj108c/Depth-Anything-2-Onnx/resolve/main/depth_anything_v2_vitl.onnx",
+        "filename": "depth_anything_v2_vitl.onnx",
+        "engine_name": "v2_depth_anything_v2_vitl-fp16.engine"
+    }
+}
+
+def download_onnx_model(model_key):
+    """Download ONNX model if it doesn't exist"""
+    if model_key not in DEPTH_ANYTHING_MODELS:
+        return f"Invalid model key: {model_key}", None
+    
+    model_info = DEPTH_ANYTHING_MODELS[model_key]
+    url = model_info["url"]
+    filename = model_info["filename"]
+    local_path = os.path.join(ONNX_DIR, filename)
+    
+    if os.path.exists(local_path):
+        return f"Model already exists at: {local_path}", local_path
+    
+    try:
+        print(f"Downloading model from {url} to {local_path}...")
+        
+        # Create a temporary file for downloading
+        temp_file = local_path + ".tmp"
+        
+        # Download the file
+        with urllib.request.urlopen(url) as response, open(temp_file, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+        
+        # Rename the temporary file to the target filename
+        shutil.move(temp_file, local_path)
+        
+        return f"Successfully downloaded model to: {local_path}", local_path
+    except Exception as e:
+        return f"Error downloading model: {str(e)}", None
+
+class DepthAnythingEngineBuilder:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": { 
+                "model_version": (list(DEPTH_ANYTHING_MODELS.keys()), {
+                    "default": "v1_large",
+                    "tooltip": "Select the Depth Anything model version and size. Larger models provide better quality but require more VRAM."
+                }),
+                "custom_engine_name": ("STRING", {
+                    "default": "",
+                    "tooltip": "Optional custom name for the TensorRT engine file. If empty, will use the default name based on the model."
+                }),
+                "use_fp16": ("BOOLEAN", {
+                    "default": True,
+                    "tooltip": "Enable FP16 precision for faster inference and lower VRAM usage. Disable if you experience stability issues."
+                }),
+                "custom_onnx_path": ("STRING", {
+                    "default": "",
+                    "optional": True,
+                    "tooltip": "Optional path to a custom ONNX model file. If provided, will use this instead of downloading the predefined model."
+                }),
+            }
+        }
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("message",)
+    FUNCTION = "build_engine"
+    CATEGORY = "tensorrt"
+    OUTPUT_NODE = True
+    
+    def build_engine(self, model_version, custom_engine_name, use_fp16, custom_onnx_path=""):
+        # Ensure directories exist
+        os.makedirs(ENGINE_DIR, exist_ok=True)
+        os.makedirs(ONNX_DIR, exist_ok=True)
+        
+        # Determine ONNX path and engine name
+        if custom_onnx_path and os.path.exists(custom_onnx_path):
+            onnx_path = custom_onnx_path
+            version = "v1" if "v1" in os.path.basename(custom_onnx_path) else "v2"
+            engine_name = custom_engine_name if custom_engine_name else f"{version}_{os.path.basename(custom_onnx_path).replace('.onnx', '-fp16.engine' if use_fp16 else '.engine')}"
+        else:
+            # Download and use predefined model
+            model_info = DEPTH_ANYTHING_MODELS[model_version]
+            message, onnx_path = download_onnx_model(model_version)
+            
+            if not onnx_path:
+                return (message,)
+                
+            engine_name = custom_engine_name if custom_engine_name else model_info["engine_name"]
+            if use_fp16 and not engine_name.endswith("-fp16.engine"):
+                engine_name = engine_name.replace(".engine", "-fp16.engine")
+            elif not use_fp16 and "-fp16.engine" in engine_name:
+                engine_name = engine_name.replace("-fp16.engine", ".engine")
+        
+        engine_path = os.path.join(ENGINE_DIR, engine_name)
+        
+        # Check if engine already exists
+        if os.path.exists(engine_path):
+            return (f"Engine already exists at: {engine_path}. Delete it manually if you want to rebuild.",)
+        
+        try:
+            print(f"Building TensorRT engine from {onnx_path} to {engine_path}...")
+            result = export_trt(trt_path=engine_path, onnx_path=onnx_path, use_fp16=use_fp16)
+            if result == 0:
+                return (f"Successfully built engine: {engine_path}",)
+            else:
+                return (f"Failed to build engine. Check console for details.",)
+        except Exception as e:
+            return (f"Error building engine: {str(e)}",)

--- a/export_trt.py
+++ b/export_trt.py
@@ -1,6 +1,6 @@
 import torch
 import time
-from utilities import Engine
+from .utilities import Engine
 
 def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):
     engine = Engine(trt_path)
@@ -18,4 +18,5 @@ def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):
 
     return ret
 
-export_trt(trt_path="./depth_anything_vitl14-fp16.engine", onnx_path="./depth_anything_vitl14.onnx", use_fp16=True)
+if __name__ == "__main__":
+    export_trt(trt_path="./depth_anything_vitl14-fp16.engine", onnx_path="./depth_anything_vitl14.onnx", use_fp16=True)

--- a/export_trt.py
+++ b/export_trt.py
@@ -1,6 +1,11 @@
 import torch
 import time
-from .utilities import Engine
+import sys
+
+try:
+    from .utilities import Engine
+except ImportError:
+    from utilities import Engine
 
 def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):
     engine = Engine(trt_path)


### PR DESCRIPTION
# Add EngineBuilder Node for Depth Anything Tensorrt

## Description
This PR adds a new EngineBuilder node to the extension, allowing users to easily build TensorRT engines from ONNX models directly in ComfyUI.

## Changes
- Created new engine builder node

## Features
- **Model Selection**: Choose from the supported ONNX models
- **Custom Engine Names**: Option to specify custom engine file names
- **Custom ONNX Models**: Support for using custom ONNX models
- **Automatic Downloads**: Auto download onnx from HF, and build engine
- **User Feedback**: Clear status messages for all operations

## Usage
1. Add the Engine Builder node to your workflow
2. Select the desired model size
3. (Optional) Configure custom engine name and FP16 settings
4. Run the workflow to build the TensorRT engine

## Technical Details
- Models are downloaded to `models/onnx/depth-anything/`
- Engines are built in `models/tensorrt/depth-anything/`
- Supports both predefined and custom ONNX models
- Includes proper error handling and status reporting

## Testing
- Tested with some models sizes in ComfyUI (method 1)
- Tested with some model sizes by running the script directly (method 2)