### PR TITLE
fix: conform DepthAnythingTensorrt IMAGE output to (B, H, W, 3)

### DIFF
--- a/nodes/depth_anything_tensorrt.py
+++ b/nodes/depth_anything_tensorrt.py
@@ -127,6 +127,7 @@ class DepthAnythingTensorrt(_DepthAnythingBase):
             result = 1 - torch.from_numpy(depth_frames_np)
         else:
             result = torch.from_numpy(depth_frames_np)
+        result = result.unsqueeze(-1).repeat(1, 1, 1, 3)
         return (result,)
 
 class DepthAnythingTensorrtAdvanced(_DepthAnythingBase):


### PR DESCRIPTION
The node output depth as (B, H, W) which does not conform to ComfyUI's IMAGE type contract of (B, H, W, 3). This causes errors in downstream nodes like Video Combine (both native and Video Helper Suite) that expect 3-channel RGB input.

Expand the grayscale depth to 3-channel RGB via unsqueeze + repeat.